### PR TITLE
[BAC-160] - cleanup namespaces in templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 
+fluent-bit/Chart.yaml

--- a/fluent-bit/templates/daemonset.yaml
+++ b/fluent-bit/templates/daemonset.yaml
@@ -4,10 +4,13 @@ kind: DaemonSet
 metadata:
   name: {{.Values.name}}
   labels:
-    app: log-app
+    app: {{ template "name" . }}
     k8s-app: fluent-bit-logging
     version: v1
     kubernetes.io/cluster-service: "true"
+    chart: "{{.Chart.Name}}-{{.Chart.Version}}"
+    release: "{{.Release.Name}}"
+    heritage: "{{.Release.Service}}"
 spec:
   template:
     metadata:

--- a/fluent-bit/templates/rbac.yaml
+++ b/fluent-bit/templates/rbac.yaml
@@ -24,7 +24,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: {{.Values.name}}
-  namespace: {{.Values.namespace}}
+  namespace: {{.Release.Namespace}}
   apiGroup: ""
 roleRef:
   kind: ClusterRole

--- a/fluent-bit/templates/rbac.yaml
+++ b/fluent-bit/templates/rbac.yaml
@@ -7,6 +7,9 @@ metadata:
     component: {{.Values.name}}
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
+    chart: "{{.Chart.Name}}-{{.Chart.Version}}"
+    release: "{{.Release.Name}}"
+    heritage: "{{.Release.Service}}"
 rules:
 - apiGroups: [""]
   resources: ["namespaces", "pods"]
@@ -21,6 +24,9 @@ metadata:
     component: {{.Values.name}}
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
+    chart: "{{.Chart.Name}}-{{.Chart.Version}}"
+    release: "{{.Release.Name}}"
+    heritage: "{{.Release.Service}}"
 subjects:
 - kind: ServiceAccount
   name: {{.Values.name}}

--- a/fluent-bit/templates/service-account.yaml
+++ b/fluent-bit/templates/service-account.yaml
@@ -7,3 +7,6 @@ metadata:
     component: {{.Values.name}}
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
+    chart: "{{.Chart.Name}}-{{.Chart.Version}}"
+    release: "{{.Release.Name}}"
+    heritage: "{{.Release.Service}}"

--- a/fluent-bit/templates/service-account.yaml
+++ b/fluent-bit/templates/service-account.yaml
@@ -3,7 +3,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{.Values.name}}
-  namespace: {{.Values.namespace}}
   labels:
     component: {{.Values.name}}
     kubernetes.io/cluster-service: "true"

--- a/fluent-bit/values.yaml
+++ b/fluent-bit/values.yaml
@@ -4,5 +4,4 @@
 # name: value
 
 name: fluent-bit
-namespace: default
 image: quay.io/samsung_cnct/fluent-bit-container:latest


### PR DESCRIPTION
**What this PR does / why we need it**: This PR removes the explicitly created namespace template value in favor of the helm provided namespace. This should be set on the helm install command. Additionally the templates can refer to `{{.Release.Namespace}}` when explicitly needed. Such as the ClusterRoleBinding resource.

**Which issue this PR fixes**:
This is part of [BAC-160][160]

**Verification Notes**:

To verify this you can install this chart into a dev cluster:
```
helm install --name fluent-bit-0 --namespace fluent-bit-test ./fluent-bit
kubectl -n fluent-bit-test get all
```

[160]: https://samsung-cnct.atlassian.net/browse/BAC-160