### PR TITLE
add hardcoded limits to daemonset

### DIFF
--- a/fluent-bit/templates/daemonset.yaml
+++ b/fluent-bit/templates/daemonset.yaml
@@ -32,6 +32,9 @@ spec:
           requests:
             cpu: 100m
             memory: 100Mi
+          limits:
+            cpu: 200m
+            memory: 200Mi
         volumeMounts:
         - name: varlog
           mountPath: /var/log


### PR DESCRIPTION
production uses a namespace that has quotas for limits and requests.
hardcoded because the requests are hardcoded so leaving it that
way.