### PR TITLE
make the resources falues templated

### DIFF
--- a/fluent-bit/templates/daemonset.yaml
+++ b/fluent-bit/templates/daemonset.yaml
@@ -30,11 +30,11 @@ spec:
             value: "9200"
         resources:
           requests:
-            cpu: 100m
-            memory: 100Mi
+            cpu: {{.Values.resources.requests.cpu}}
+            memory: {{.Values.resources.requests.mem}}
           limits:
-            cpu: 200m
-            memory: 200Mi
+            cpu: {{.Values.resources.limits.cpu}}
+            memory: {{.Values.resources.limits.mem}}
         volumeMounts:
         - name: varlog
           mountPath: /var/log

--- a/fluent-bit/values.yaml
+++ b/fluent-bit/values.yaml
@@ -6,6 +6,14 @@
 name: fluent-bit
 image: quay.io/samsung_cnct/fluent-bit-container:latest
 
+resources:
+  requests:
+    cpu: 100m
+    mem: 500Mi
+  limits:
+    cpu: 300m
+    mem: 1000Mi
+
 #  example toleration
 #tolerations:
 #  - key: taintKey


### PR DESCRIPTION
we are seeing very high usage rates for fluentbit on some nodes.
we are unable to diagnose what's going on because kubernetes is
OOM Killing the pods, which then restart and the cycle continues