### PR TITLE
pin version of fluent-bit by default

### DIFF
--- a/fluent-bit/values.yaml
+++ b/fluent-bit/values.yaml
@@ -4,7 +4,7 @@
 # name: value
 
 name: fluent-bit
-image: quay.io/samsung_cnct/fluent-bit-container:latest
+image: quay.io/samsung_cnct/fluent-bit-container:v0.0.1
 
 resources:
   requests:


### PR DESCRIPTION
this value can always be overriden but we should be using a pinned
version by default