### PR TITLE
[CO-233] Parameterize hostname and port of elasticsearch log sink.

### DIFF
--- a/fluent-bit/templates/daemonset.yaml
+++ b/fluent-bit/templates/daemonset.yaml
@@ -25,9 +25,9 @@ spec:
         image: {{.Values.image}}
         env:
           - name:  FLUENT_ELASTICSEARCH_HOST
-            value: "elasticsearch"
+            value: "{{.Values.elasticSearchHost}}"
           - name:  FLUENT_ELASTICSEARCH_PORT
-            value: "9200"
+            value: "{{.Values.elasticSearchPort}}"
         resources:
           requests:
             cpu: {{.Values.resources.requests.cpu}}

--- a/fluent-bit/values.yaml
+++ b/fluent-bit/values.yaml
@@ -14,6 +14,9 @@ resources:
     cpu: 300m
     mem: 1000Mi
 
+elasticSearchHost: elasticsearch 
+elasticSearchPort: 9200
+
 #  example toleration
 #tolerations:
 #  - key: taintKey


### PR DESCRIPTION
This is necessary to point `fluent-bit` to an arbitrary remote `elasticsearch` cluster.