### PR TITLE
CO-275 Add configmap

### DIFF
--- a/charts/fluent-bit/templates/configmap.yaml
+++ b/charts/fluent-bit/templates/configmap.yaml
@@ -15,6 +15,8 @@ data:
 {{ $val | indent 4}}
 {{- end }}
 {{ else }}
-  fluent-bit.yaml: |-
-{{- include "fluent-bit.yaml.tpl" . | indent 4}}
+  fluent-bit.conf: |-
+{{- include "fluent-bit.conf.tpl" . | indent 4}}
+  parsers.conf: |-
+{{- include "parsers.conf.tpl" . | indent 4}}
 {{ end }}

--- a/charts/fluent-bit/templates/configmap.yaml
+++ b/charts/fluent-bit/templates/configmap.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "name" . }}
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ template "namewithversion" . }}
+    release: "{{.Release.Name}}"
+    heritage: "{{.Release.Service}}"
+data:
+{{- if .Values.config }}
+{{- $root := . }}
+{{- range $key, $val := .Values.config }}
+  {{ $key }}: |-
+{{ $val | indent 4}}
+{{- end }}
+{{ else }}
+  fluent-bit.yaml: |-
+{{- include "fluent-bit.yaml.tpl" . | indent 4}}
+{{ end }}

--- a/charts/fluent-bit/templates/fluent-bit.conf.tpl
+++ b/charts/fluent-bit/templates/fluent-bit.conf.tpl
@@ -1,0 +1,35 @@
+{{ define "fluent-bit.conf.tpl" }}
+[SERVICE]
+    Flush        1
+    Log_Level    info
+    Parsers_File parsers.conf
+
+[INPUT]
+    Name            systemd
+    Tag             host.*
+    Path            /var/log/journal
+    Mem_Buf_Limit 5MB
+
+[INPUT]
+    Name          tail
+    Path          /var/log/containers/*.log
+    Exclude_Path  /var/log/containers/fluent*.log
+    Parser        docker
+    Tag           kube.*
+    DB            /var/log/flb_kube.db
+    Skip_Long_Lines On
+    Mem_Buf_Limit 5MB
+
+[FILTER]
+    Name   kubernetes
+    Match  kube.*
+    Merge_JSON_Log On
+
+[OUTPUT]
+    Name  es
+    Match *
+    Host  ${FLUENT_ELASTICSEARCH_HOST}
+    Port  ${FLUENT_ELASTICSEARCH_PORT}
+    Logstash_Format On
+    Retry_Limit False
+{{ end }}

--- a/charts/fluent-bit/templates/fluent-bit.yaml.tpl
+++ b/charts/fluent-bit/templates/fluent-bit.yaml.tpl
@@ -1,0 +1,3 @@
+{{ define "fluent-bit.yaml.tpl" }}
+item: null
+{{ end }}

--- a/charts/fluent-bit/templates/fluent-bit.yaml.tpl
+++ b/charts/fluent-bit/templates/fluent-bit.yaml.tpl
@@ -1,3 +1,0 @@
-{{ define "fluent-bit.yaml.tpl" }}
-item: null
-{{ end }}

--- a/charts/fluent-bit/templates/parsers.conf.tpl
+++ b/charts/fluent-bit/templates/parsers.conf.tpl
@@ -1,0 +1,47 @@
+{{ define "parsers.conf.tpl" }}
+[PARSER]
+    Name   apache
+    Format regex
+    Regex  ^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*?)(?: +\S*)?)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$
+    Time_Key time
+    Time_Format %d/%b/%Y:%H:%M:%S %z
+
+[PARSER]
+    Name   apache2
+    Format regex
+    Regex  ^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^ ]*) +\S*)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$
+    Time_Key time
+    Time_Format %d/%b/%Y:%H:%M:%S %z
+
+[PARSER]
+    Name   apache_error
+    Format regex
+    Regex  ^\[[^ ]* (?<time>[^\]]*)\] \[(?<level>[^\]]*)\](?: \[pid (?<pid>[^\]]*)\])?( \[client (?<client>[^\]]*)\])? (?<message>.*)$
+
+[PARSER]
+    Name   nginx
+    Format regex
+    Regex ^(?<remote>[^ ]*) (?<host>[^ ]*) (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*?)(?: +\S*)?)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$
+    Time_Key time
+    Time_Format %d/%b/%Y:%H:%M:%S %z
+
+[PARSER]
+    Name   json-test
+    Format json
+    Time_Key time
+    Time_Format %d/%b/%Y:%H:%M:%S %z
+
+[PARSER]
+    Name        docker
+    Format      json
+    Time_Key    time
+    Time_Format %Y-%m-%dT%H:%M:%S
+    Time_Keep   On
+
+[PARSER]
+    Name        syslog
+    Format      regex
+    Regex       ^\<(?<pri>[0-9]+)\>(?<time>[^ ]* {1,2}[^ ]* [^ ]*) (?<host>[^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$
+    Time_Key    time
+    Time_Format %b %d %H:%M:%S
+{{ end }}


### PR DESCRIPTION
This PR adds the existing fluent-bit config files as ConfigMap data.

- fluent-bit.conf
- parsers.conf

A few thoughts about next steps.

fluent-bit.conf can have multiple `[INPUT]` entries. We could make this a loop of key/value pairs for each INPUT block.

parsers.conf can have multiple `[PARSER]` entries. We could make this a loop of key/value pairs for each PARSER block.