### PR TITLE
[CO-275] Use the fluent-bit configuration overrides instead of

### DIFF
--- a/charts/fluent-bit/templates/configmap.yaml
+++ b/charts/fluent-bit/templates/configmap.yaml
@@ -5,18 +5,18 @@ metadata:
   labels:
     app: {{ template "name" . }}
     chart: {{ template "namewithversion" . }}
-    release: "{{.Release.Name}}"
-    heritage: "{{.Release.Service}}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
 data:
-{{- if .Values.config }}
-{{- $root := . }}
-{{- range $key, $val := .Values.config }}
-  {{ $key }}: |-
-{{ $val | indent 4}}
-{{- end }}
-{{ else }}
   fluent-bit.conf: |-
-{{- include "fluent-bit.conf.tpl" . | indent 4}}
+{{- if .Values.config }}
+{{ .Values.config | indent 4 }}
+{{- else }}
+{{- include "fluent-bit.conf.tpl" . | indent 4 }}
+{{- end }}
   parsers.conf: |-
-{{- include "parsers.conf.tpl" . | indent 4}}
-{{ end }}
+{{- if .Values.parsers }}
+{{ .Values.parsers | indent 4 }}
+{{- else }}
+{{- include "parsers.conf.tpl" . | indent 4 }}
+{{- end }}

--- a/charts/fluent-bit/templates/daemonset.yaml
+++ b/charts/fluent-bit/templates/daemonset.yaml
@@ -24,10 +24,10 @@ spec:
         - name: {{.Values.name}}
           image: {{.Values.image}}
           env:
-            - name: FLUENT_ELASTICSEARCH_HOST
-              value: "{{.Values.elasticSearchHost}}"
-            - name: FLUENT_ELASTICSEARCH_PORT
-              value: "{{.Values.elasticSearchPort}}"
+          - name: FLUENT_ELASTICSEARCH_HOST
+            value: "{{.Values.elasticSearchHost}}"
+          - name: FLUENT_ELASTICSEARCH_PORT
+            value: "{{.Values.elasticSearchPort}}"
           resources:
             requests:
               cpu: {{.Values.resources.requests.cpu}}
@@ -36,11 +36,17 @@ spec:
               cpu: {{.Values.resources.limits.cpu}}
               memory: {{.Values.resources.limits.mem}}
           volumeMounts:
-            - name: varlog
-              mountPath: /var/log
-            - name: varlibdockercontainers
-              mountPath: /var/lib/docker/containers
-              readOnly: true
+          - name: fbconfig
+            mountPath: /fluent-bit/etc/fluent-bit.conf
+            subPath: fluent-bit.conf
+          - name: fbconfig
+            mountPath: /fluent-bit/etc/parsers.conf
+            subPath: parsers.conf
+          - name: varlog
+            mountPath: /var/log
+          - name: varlibdockercontainers
+            mountPath: /var/lib/docker/containers
+            readOnly: true
       {{- if .Values.tolerations}}
       tolerations:
       {{- range .Values.tolerations}}
@@ -52,9 +58,12 @@ spec:
       {{- end}}
       terminationGracePeriodSeconds: 10
       volumes:
-        - name: varlog
-          hostPath:
-            path: /var/log
-        - name: varlibdockercontainers
-          hostPath:
-            path: /var/lib/docker/containers
+      - name: fbconfig
+        configMap:
+          name: {{ template "name" . }}
+      - name: varlog
+        hostPath:
+          path: /var/log
+      - name: varlibdockercontainers
+        hostPath:
+          path: /var/lib/docker/containers

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -14,3 +14,7 @@ resources:
 
 elasticSearchHost: elasticsearch
 elasticSearchPort: 9200
+
+#config: |-
+
+#parsers: |-


### PR DESCRIPTION
unconditionally falling back to the container versions.